### PR TITLE
use a non-sa username for sqlrelay connection to mssql

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,6 +73,8 @@ jobs:
         run: sleep 15
       - name: test mssql
         run: bash bin/mssql.sh test
+      - name: setup mssql
+        run: bash bin/mssql.sh setup
       - name: config sqlrelay
         run: bash bin/sqlrelay.sh config
       - name: start sqlrelay

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,6 +81,8 @@ jobs:
         run: bash bin/sqlrelay.sh start
       - name: test sqlrelay
         run: bash bin/sqlrelay.sh test
+      - name: show sqlrelay 1
+        run: bash bin/sqlrelay.sh show
       - name: Run tests
         run: >-
           SQLR_CLIENT_DEBUG_PREFIX=artifacts/client-log/
@@ -98,6 +100,9 @@ jobs:
           -d extension=$(php -r 'echo PHP_EXTENSION_DIR;')/pdo.so
           -d extension=pdo_sqlrelay.so
           tests
+      - name: show sqlrelay 2
+        if: always()
+        run: bash bin/sqlrelay.sh show
       - name: stop sqlrelay
         if: always()
         run: bash bin/sqlrelay.sh stop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,8 @@ jobs:
         run: bash bin/sqlrelay.sh start
       - name: test sqlrelay
         run: bash bin/sqlrelay.sh test
+      - name: show sqlrelay 1
+        run: bash bin/sqlrelay.sh show
       - name: Run tests
         run: >-
           SQLR_CLIENT_DEBUG_PREFIX=artifacts/client-log/
@@ -92,6 +94,9 @@ jobs:
           -d extension=$(php -r 'echo PHP_EXTENSION_DIR;')/pdo.so
           -d extension=pdo_sqlrelay.so
           tests
+      - name: show sqlrelay 2
+        if: always()
+        run: bash bin/sqlrelay.sh show
       - name: stop sqlrelay
         if: always()
         run: bash bin/sqlrelay.sh stop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,8 @@ jobs:
         run: sleep 15
       - name: test mssql
         run: bash bin/mssql.sh test
+      - name: setup mssql
+        run: bash bin/mssql.sh setup
       - name: config sqlrelay
         run: bash bin/sqlrelay.sh config
       - name: start sqlrelay

--- a/bin/sqlrelay.sh
+++ b/bin/sqlrelay.sh
@@ -30,7 +30,10 @@ ping;
 sqlrcmd gstat;
 sqlrcmd cstat;
 SELECT CAST(HOST_NAME() as VARCHAR(64)) as HOST_NAME,
-       CAST(APP_NAME() as VARCHAR(64)) as APP_NAME;
+       CAST(APP_NAME() as VARCHAR(64)) as APP_NAME,
+       USER_NAME() as CURRENT_USER_NAME,
+       SCHEMA_NAME() as SCHEMA_NAME,
+       DB_NAME() as DBNAME;
 EOF
     t0=$(date +%s)
     sqlrsh -id test -command "$sqlrsh_query"

--- a/data/test.conf
+++ b/data/test.conf
@@ -36,7 +36,7 @@
     <connections>
       <connection
           connectionid="test.1"
-          string="driver=ODBC Driver 17 for SQL Server;server=127.0.0.1;user=sa;password=None-123;db=master;trace=yes;tracefile=__ODBC_TRACE_DIRECTORY__/test.%t.%p.txt;detachbeforelogin=yes;lastinsertidquery=select @@identity;faketransactionblocks=yes;autocommit=yes;timeout=60;querytimeout=300;executedirect=yes;maxcolumncount=400;maxfieldlength=32768;"
+          string="driver=ODBC Driver 17 for SQL Server;server=127.0.0.1;user=test2;password=None-123#BAR;db=master;trace=yes;tracefile=__ODBC_TRACE_DIRECTORY__/test.%t.%p.txt;detachbeforelogin=yes;lastinsertidquery=select @@identity;faketransactionblocks=yes;autocommit=yes;timeout=60;querytimeout=300;executedirect=yes;maxcolumncount=400;maxfieldlength=32768;"
          />
     </connections>
     <queries>


### PR DESCRIPTION
## Description
Creating and use a non-sa username for the sqlrelay config connection to mssql will allow for easier testing with other servers.


